### PR TITLE
Fixed ItemResource add_metadata

### DIFF
--- a/lib/dspace/resources/item_resource.rb
+++ b/lib/dspace/resources/item_resource.rb
@@ -45,7 +45,7 @@ module Dspace
         end
 
         action :add_metadata, 'POST /rest/items/:id/metadata' do
-          body { |objects| Dspace::Builders::ModelBuilder.models2hash(objects) }
+          body { |objects| JSON.generate(objects) }
           handler(200, 201) { |response| true }
         end
 


### PR DESCRIPTION
Changed add_metadata to encode objects with JSON before sending the request to DSpace.
Signed-off-by: Israel Barreto Sant'Anna <ibsa14@inf.ufpr.br>